### PR TITLE
Feature/add influxdb webhook template

### DIFF
--- a/influxdb.yml
+++ b/influxdb.yml
@@ -1,0 +1,19 @@
+template-id: influxdbcloud
+name: InfluxDB Cloud 2.0
+description: Use HTTP webhook with Telegraf agent to connect to InfluxDB Cloud 2.0
+logo-url: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c6/Influxdb_logo.svg/1200px-Influxdb_logo.svg.png
+info-url: https://www.influxdata.com/
+documentation-url: https://v2.docs.influxdata.com/v2.0/
+fields:
+  - id: path
+    name: URL path
+    description: Path which Telegraf agent is listening to
+    secret: false
+    default-value: 
+format: json
+headers: {}
+create-downlink-api-key: false
+base-url: http://localhost:8080{/path}
+paths: 
+  uplink-message: ""
+ 

--- a/templates.yml
+++ b/templates.yml
@@ -2,3 +2,4 @@
 - datacake
 - tago
 - akenza
+- influxdb


### PR DESCRIPTION
#### Summary
Adding a webhook template for InfluxDB Cloud 2.0

#### Notes for Reviewers
@adriansmares I read that the most common URL is http://localhost:8080/telegraf and only path (/telegraf) is usually being changed, but I kinda wasn't sure - does using something else than localhost:8080 make sense? 

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible, they don't break existing deployments.
- [x] Testing: The changes are tested.
- [x] Documentation: Relevant documentation is added or updated.
