### PR TITLE
Update the Tago webhook template

### DIFF
--- a/tago.yml
+++ b/tago.yml
@@ -3,18 +3,18 @@ name: TagoIO
 description: Integrate with TagoIO
 logo-url: https://partners.sigfox.com/assets/logo-for/5acccca69bffaf0001201a45
 info-url: https://tago.io/
-documentation-url: https://docs.tago.io/
+documentation-url: https://community.tago.io/t/how-to-integrate-tagoio-with-ttn-v3/374
 fields:
-  - id: token
-    name: Device Token
-    description: TagoIO device token
+  - id: auth
+    name: Authorization
+    description: TagoIO Authorization
     secret: true
     default-value: 
 format: json
 headers:
-  Device-Token: "{token}"
+  Authorization: "{auth}"
   Content-Type: application/json
-create-downlink-api-key: false
-base-url: https://api.tago.io/data
+create-downlink-api-key: true
+base-url: https://ttn.middleware.tago.io
 paths:
-  uplink-message: /
+  uplink-message: /uplink


### PR DESCRIPTION
#### Summary
Updating the webhook template after Tago's review. 

#### Changes
Using the device token from Tago for granting the access to the external services is now switched to using the Service Authorization parameter. BaseURL parameter and documentation info URL are changed, downlink API key is now being created.

#### Notes for Reviewers
I tested this with TTS running locally and it works. I will update the documentation asap.

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible, they don't break existing deployments.
- [x] Testing: The changes are tested.
- [ ] Documentation: Relevant documentation is added or updated.
