### PR TITLE
Fix Akenza logo URL

### DIFF
--- a/akenza.yml
+++ b/akenza.yml
@@ -1,7 +1,7 @@
 template-id: akenza
 name: Akenza Core
 description: Integrate with Akenza Core
-logo-url: https://res.cloudinary.com/teamtailor/image/upload/c_limit,f_auto,h_900,w_1600/v1566979018/hl9jdiprpqfyxuzha3zn.jpg
+logo-url: https://www.thethingsnetwork.org/conference/wp-content/uploads/2020/01/Akenza-LogoClaim-rgb-positive_nb.png
 info-url: https://core.akenza.io/
 documentation-url: https://akenza.atlassian.net/servicedesk/customer/portals/
 fields:


### PR DESCRIPTION
#### Summary
Added a working Akenza logo URL.

#### Notes for Reviewers
This is just a temporary solution until the serving webhook template logos issue (https://github.com/TheThingsNetwork/lorawan-stack/issues/3357) is resolved.

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible, they don't break existing deployments.
- [x] Testing: The changes are tested.
- [x] Documentation: Relevant documentation is added or updated.
