### PR TITLE
Fix BaseURL

### DIFF
--- a/thethingsio.yml
+++ b/thethingsio.yml
@@ -18,6 +18,6 @@ fields:
 format: json
 headers: {}
 create-downlink-api-key: false
-base-url: https://subscription.thethings.io/lora/{productID}/{callbackID}?idname=end_device_ids.dev_eui
+base-url: https://subscription.thethings.io/lora/{productID}/{hash}?idname=end_device_ids.dev_eui
 paths:
   uplink-message: ""


### PR DESCRIPTION
#### Summary
Closes [Wrong Base URL generated when using thethings.iO webhook template](https://github.com/TheThingsIndustries/lorawan-stack-support/issues/353)

#### Changes
Replacing `callbackID` with `hash`

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible, they don't break existing deployments.
- [x] Testing: The changes are tested.
- [ ] Documentation: Relevant documentation is added or updated.
