### PR TITLE
doc: Remove excess slash in paths

### DIFF
--- a/wonderland.yml
+++ b/wonderland.yml
@@ -21,13 +21,13 @@ headers:
 create-downlink-api-key: true
 base-url: https://api.lorawonderland.com/master/tts_integration.php{/username}
 paths:
-  uplink-message: /
-  join-accept: /
-  downlink-ack: /
-  downlink-nack: /
-  downlink-sent: /
-  downlink-failed: /
-  downlink-queued: /
-  downlink-queue-invalidated: /
-  location-solved: /
-  service-data: /
+  uplink-message: ""
+  join-accept: ""
+  downlink-ack: ""
+  downlink-nack: ""
+  downlink-sent: ""
+  downlink-failed: ""
+  downlink-queued: ""
+  downlink-queue-invalidated: ""
+  location-solved: ""
+  service-data: ""


### PR DESCRIPTION
#### Summary
Fix paths in Wonderland template

#### Changes
An excess slash configured in paths is causing a 404 Not found error.

#### Checklist
- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible, they don't break existing deployments.
- [ ] Testing: The changes are tested.
- [ ] Documentation: Relevant documentation is added or updated.
