### PR TITLE
Add zoho iot webhook template

### DIFF
--- a/templates.yml
+++ b/templates.yml
@@ -31,3 +31,4 @@
 - wonderland
 - traxmate
 - sensgreen
+- zoho-iot

--- a/zoho-iot.yml
+++ b/zoho-iot.yml
@@ -1,0 +1,30 @@
+template-id: zoho-iot
+name: Zoho IoT
+description: >
+  Forward uplink messages securely to Zoho IoT.
+logo-url: https://zdblogs.zohocorp.com/sites/iot/iot-hub/files/group_12.jpg
+info-url: https://www.zoho.com/iot
+documentation-url: https://help.zoho.com/portal/en/kb/iot/devices/working-with-datastreams/articles/connectivity-guide-the-things-stack
+fields:
+  - id: endpoint
+    name: URL Param Implementation
+    description: >
+      Enter the URL Param Implementation value of your Zoho IoT Data Stream.
+      Example: https://57913xxxxx.zohoiothub.com/v1/iot/datastream/589600000147xxx?token=f5zzzzzzzzzzzz
+    secret: false
+format: json
+create-downlink-api-key: false
+base-url: "{+endpoint}"
+paths:
+  uplink-message: ""
+body:
+  uplink-message:
+    device: "{{end_device_ids.device_id}}"
+    dev_eui: "{{end_device_ids.dev_eui}}"
+    application: "{{end_device_ids.application_ids.application_id}}"
+    time: "{{received_at}}"
+    f_port: "{{data.uplink_message.f_port}}"
+    f_cnt: "{{data.uplink_message.f_cnt}}"
+    payload_raw: "{{data.uplink_message.frm_payload}}"
+    decoded_payload: "{{data.uplink_message.decoded_payload}}"
+    rx_metadata: "{{data.uplink_message.rx_metadata}}"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request adds a new webhook integration template for **Zoho IoT**, enabling users to seamlessly forward uplink data from The Things Stack to Zoho’s IoT platform.


#### Changes
<!-- What are the changes made in this pull request? -->

- Added `zoho-iot.yml` defining the Zoho IoT webhook template.
- Updated `templates.yml` to register the Zoho IoT integration.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- The integration has been tested on a local The Things Stack deployment with the Zoho IoT platform.
- More details about the integration setup can be found here:  
  [Zoho IoT – Connectivity Guide (The Things Stack)](https://help.zoho.com/portal/en/kb/iot/temporary-docs/articles/the-things-stack-datastream-integration#Using_the_Global_Dashboard)
- Please advise on how to include documentation under **The Things Stack Cloud Integrations** section.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible, they don't break existing deployments.
- [x] Testing: The changes are tested.
- [x] Documentation: Relevant documentation is added or updated.
