### PR TITLE
Add Lumra webhook template

### DIFF
--- a/lumra.yml
+++ b/lumra.yml
@@ -1,0 +1,19 @@
+template-id: lumra
+name: Lumra
+description: Seal each uplink into a tamper-evident, independently verifiable record of what your devices reported
+logo-url: https://privinet.net/og/lumra.png
+info-url: https://privinet.net/
+documentation-url: https://privinet.net/api.html
+tts-documentation-url: https://www.thethingsindustries.com/docs/integrations/cloud-integrations/
+fields:
+  - id: api_key
+    name: Lumra API key
+    description: Your pk_live API key from privinet.net signup
+    secret: true
+format: json
+headers:
+  Authorization: Bearer {api_key}
+create-downlink-api-key: false
+base-url: https://api.privinet.net
+paths:
+  uplink-message: /v1/ingest/raw

--- a/templates.yml
+++ b/templates.yml
@@ -12,6 +12,7 @@
 - homey
 - iot-factory
 - losant
+- lumra
 - mclimate
 - mydevices
 - myiotopentech


### PR DESCRIPTION
#### Summary

Adds a webhook template for Lumra (https://privinet.net), a service by PriviNet that seals incoming events into tamper-evident, independently verifiable records. Pointing the uplink message at Lumra gives users a signed, hash-chained record of each uplink, with an exportable proof bundle that can be verified offline.

#### Changes

- Add lumra.yml webhook template (uplink messages only)
- Register lumra in templates.yml

#### Notes for Reviewers

The endpoint accepts The Things Stack v3 uplink JSON as-is at https://api.privinet.net/v1/ingest/raw. Authentication is a bearer API key from self-serve signup, exposed as a secret api_key template field and injected into the Authorization header.

Tested today against a live The Things Stack Sandbox (nam1) application: a custom webhook configured with exactly the base URL, path, and header from this template delivered simulated uplinks; each returned HTTP 200 and produced a sealed, signature-verified record on the Lumra side. Integration docs for users are at https://privinet.net/api.html.